### PR TITLE
[고도화] 해시태그에 대문자를 사용하여 등록 시 오류 발생

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/service/HashtagService.java
+++ b/src/main/java/com/fastcampus/projectboard/service/HashtagService.java
@@ -33,7 +33,7 @@ public class HashtagService {
         Set<String> result = new HashSet<>();
 
         while (matcher.find()) {
-            result.add(matcher.group().replace("#", ""));
+            result.add(matcher.group().replace("#", "").toLowerCase());
         }
 
         return Set.copyOf(result);

--- a/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -208,13 +209,15 @@ class ArticleServiceTest {
         // Given
         ArticleDto dto = createArticleDto();
         Set<String> expectedHashtagNames = Set.of("java", "spring");
-        Set<Hashtag> expectedHashtags = new HashSet<>();
-        expectedHashtags.add(createHashtag("java"));
+        Set<Hashtag> expectedExistingHashtags = new HashSet<>();
+        expectedExistingHashtags.add(createHashtag("java"));
+        Article expectedArticle = createArticle();
+        ArgumentCaptor<Article> articleCaptor = ArgumentCaptor.forClass(Article.class);
 
         given(userAccountRepository.getReferenceById(dto.userAccountDto().userId())).willReturn(createUserAccount());
         given(hashtagService.parseHashtagNames(dto.content())).willReturn(expectedHashtagNames);
-        given(hashtagService.findHashtagsByNames(expectedHashtagNames)).willReturn(expectedHashtags);
-        given(articleRepository.save(any(Article.class))).willReturn(createArticle());
+        given(hashtagService.findHashtagsByNames(expectedHashtagNames)).willReturn(expectedExistingHashtags);
+        given(articleRepository.save(any(Article.class))).willReturn(expectedArticle);
 
         // When
         sut.saveArticle(dto);
@@ -223,7 +226,13 @@ class ArticleServiceTest {
         then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
         then(hashtagService).should().parseHashtagNames(dto.content());
         then(hashtagService).should().findHashtagsByNames(expectedHashtagNames);
-        then(articleRepository).should().save(any(Article.class));
+        then(articleRepository).should().save(articleCaptor.capture());
+        assertThat(articleCaptor.getValue())
+                .hasFieldOrPropertyWithValue("title", dto.title())
+                .hasFieldOrPropertyWithValue("content", dto.content())
+                .extracting("hashtags", as(InstanceOfAssertFactories.COLLECTION))
+                .extracting("hashtagName")
+                .containsExactlyInAnyOrderElementsOf(expectedHashtagNames);
     }
 
     @Test

--- a/src/test/java/com/fastcampus/projectboard/service/HashtagServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/HashtagServiceTest.java
@@ -31,8 +31,8 @@ class HashtagServiceTest {
 
     @MethodSource
     @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
-    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복 없이 반환한다.")
-    void givenContent_whenParsing_thenReturnsUniqueHashtagNames(String input, Set<String> expected) {
+    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복 없이 대소문자를 무시하고 반환한다.")
+    void givenContent_whenParsing_thenReturnsUniqueHashtagNamesIgnoringCase(String input, Set<String> expected) {
         // Given
 
         // When
@@ -43,7 +43,7 @@ class HashtagServiceTest {
         then(hashtagRepository).shouldHaveNoInteractions();
     }
 
-    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNames() {
+    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNamesIgnoringCase() {
         return Stream.of(
                 arguments(null, Set.of()),
                 arguments("", Set.of()),
@@ -77,6 +77,7 @@ class HashtagServiceTest {
                 arguments("   #java,? #spring  ...  #부트 ", Set.of("java", "spring", "부트")),
                 arguments("#java#java#spring#부트", Set.of("java", "spring", "부트")),
                 arguments("#java#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#JAVA#Java#sPRINg#부트", Set.of("java", "spring", "부트")),
                 arguments("#java#spring#java#부트#java", Set.of("java", "spring", "부트")),
                 arguments("#java#스프링 아주 긴 글~~~~~~~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
                 arguments("아주 긴 글~~~~~~~~~~~~~~~~~~~~~#java#스프링", Set.of("java", "스프링")),


### PR DESCRIPTION
이 pr은 게시글을 저장할 때, 함께 저장하는 해시태그의 대소문자를 가리지 않도록 기능을 수정합니다.

this closes #101 